### PR TITLE
bump inferenceql.inference -> 40e77dedf680b7936ce988b66186a86f5c4db6a5

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:deps {clj-python/libpython-clj {:mvn/version "2.023"}
-        io.github.inferenceql/inferenceql.inference {:git/sha "e1dcd0f2721dcdef388f8270dc9bd80eecde3ef9"}
+        io.github.inferenceql/inferenceql.inference {:git/sha "40e77dedf680b7936ce988b66186a86f5c4db6a5"}
         medley/medley {:mvn/version "1.3.0"}}
 
  :aliases {:test {:extra-paths ["test/src"


### PR DESCRIPTION
Bumps this dependency to latest.

To match https://github.com/InferenceQL/inferenceql.query/blob/main/deps.edn#L8.

Though it may not be necessary, it simplifies transitive dependency management and allows Nix to build `inferenceql.query` with this dependency included. Since (AFAIK) handling two different dependency caches/lockfiles is fairly complex in Nix with Clojure, this is the simplest thing to do. Later we can easily have various lockfiles that are minimal for a given situation, i.e. one without this lib and one with.